### PR TITLE
overwrite: Encode output to utf-8 to prevent error

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -248,7 +248,7 @@ class InstafailingTerminalReporter(TerminalReporter):
         return full_line  
 
     def overwrite(self, line):
-        sys.stdout.write("\r" + self.append_string(line))
+        sys.stdout.write("\r" + self.append_string(line).encode('utf-8'))
         sys.stdout.flush()
 
     def pytest_runtest_logreport(self, report):


### PR DESCRIPTION
I needed to make this change to prevent the following error when running `py.test`:

```
INTERNALERROR>   File "/Users/marca/dev/git-repos/pytest-sugar/pytest_sugar.py", line 264, in pytest_runtest_logreport
INTERNALERROR>     self.overwrite(self.insert_progress())
INTERNALERROR>   File "/Users/marca/dev/git-repos/pytest-sugar/pytest_sugar.py", line 251, in overwrite
INTERNALERROR>     sys.stdout.write("\r" + self.append_string(line))
INTERNALERROR> UnicodeEncodeError: 'ascii' codec can't encode character u'\u2713' in position 52: ordinal not in range(128)
```

The problem is that Python's default encoding, AFAIK, is ASCII, so if you try to write a non-ASCII Unicode character (in this case, U+2713, the checkmark, ✓), you get a `UnicodeEncodeError`.

I guess that you didn't see this error on your system? Which is curious. I wonder if you have configured Python or your terminal to use UTF-8 so that masked the problem?

In any case, I think this change will make pytest-sugar work on a wider variety of systems.
