### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.egg-info
 *.pyc
+.tox
 dist/

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,12 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27, py33, pypy
+
+[testenv]
+commands = py.test
+deps =
+    pytest


### PR DESCRIPTION
Adds support for testing against multiple Python versions with [tox](https://testrun.org/)
## Example:

```
marca@marca-mac2:~/dev/git-repos/pytest-sugar (master●)
$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  py33: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

Cc: @Frozenball, @sontek, @aconrad
