### PR TITLE
tox.ini: Accept {posargs} and pass to py.test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,6 @@
 envlist = py26, py27, py32, py33, pypy
 
 [testenv]
-commands = py.test
+commands = py.test {posargs:test_sugar.py}
 deps =
     pytest


### PR DESCRIPTION
This allows one to specify arguments to tox (after "--") and have it pass them to py.test -- e.g.:

```
$ tox -- --verbose
```

Cc: @Frozenball, @kevinburke
