### PR TITLE
Remove use_2to3, use unicode_literals

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -8,6 +8,7 @@ py.test plugin to show failures instantly.
 :copyright: see LICENSE for details
 :license: BSD, see LICENSE for more details.
 """
+from __future__ import unicode_literals
 import pytest
 import py
 import sys
@@ -153,13 +154,13 @@ def pytest_configure(config):
 
 def _pytest_report_teststatus(report):
     if report.passed:
-        letter = bcolors.OKGREEN+u'✓'+bcolors.ENDC
+        letter = bcolors.OKGREEN+'✓'+bcolors.ENDC
     elif report.skipped:
-        letter = bcolors.OKBLUE+u's'+bcolors.ENDC
+        letter = bcolors.OKBLUE+'s'+bcolors.ENDC
     elif report.failed:
-        letter = bcolors.FAIL+u'⨯'+bcolors.ENDC
+        letter = bcolors.FAIL+'⨯'+bcolors.ENDC
         if report.when != "call":
-            letter = bcolors.FAIL+u'ₓ'+bcolors.ENDC
+            letter = bcolors.FAIL+'ₓ'+bcolors.ENDC
     return report.outcome, letter, report.outcome.upper()
 
 
@@ -172,7 +173,7 @@ class InstafailingTerminalReporter(TerminalReporter):
         self.paths_left = []
         self.tests_count = 0
         self.tests_taken = 0
-        self.current_line = u''
+        self.current_line = ''
         self.currentfspath2 = ''
         self.time_taken = {}
         self.reports = []
@@ -226,26 +227,26 @@ class InstafailingTerminalReporter(TerminalReporter):
 
         def get_progress_bar():
             blocks = [
-                u'█',
-                u'▉',
-                u'▉',
-                u'▊',
-                u'▊',
-                u'▋',
-                u'▋',
-                u'▌',
-                u'▌',
-                u'▍',
-                u'▍',
-                u'▎',
-                u'▎',
-                u'▏',
-                u'▏'
+                '█',
+                '▉',
+                '▉',
+                '▊',
+                '▊',
+                '▋',
+                '▋',
+                '▌',
+                '▌',
+                '▍',
+                '▍',
+                '▎',
+                '▎',
+                '▏',
+                '▏'
             ]
             length = 10
             p = float(self.tests_taken) / self.tests_count
             floored = int(round(p * length))
-            progressbar = u''
+            progressbar = ''
             progressbar += "%i%% " % round(p*100)
             progressbar += bcolors.OKGREEN
             progressbar += blocks[0] * floored
@@ -289,12 +290,12 @@ class InstafailingTerminalReporter(TerminalReporter):
                 self.currentfspath2 = report.fspath
                 basename = os.path.basename(report.fspath)
                 self.current_line = (
-                    u"   " +
+                    "   " +
                     bcolors.GRAY +
                     report.fspath[0:-len(basename)] +
                     bcolors.ENDC +
                     report.fspath[-len(basename):] +
-                    u" "
+                    " "
                 )
                 print("")
 
@@ -395,5 +396,5 @@ class InstafailingTerminalReporter(TerminalReporter):
                 elif report.when == "teardown":
                     msg = "ERROR at teardown of " + msg
                 self.write_line('')
-                self.write_sep(u"―", msg)
+                self.write_sep("―", msg)
                 self._outrep_summary(report)

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,6 @@ setup(
     include_package_data=True,
     platforms='any',
     install_requires=['pytest>=2.3'],
-    use_2to3=True,
     classifiers=[
         'Development Status :: 3 - Alpha',
         'Intended Audience :: Developers',
@@ -27,7 +26,6 @@ setup(
         'Topic :: Software Development :: Libraries',
         'Topic :: Utilities',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.5',
         'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
This is an alternative to https://github.com/Frozenball/pytest-sugar/pull/13 for eliminating `use_2to3=True` from `setup.py`.
- `setup.py`: Remove `use_2to3=True`, remove Python 2.5
- `pytest_sugar.py`: Add `from __future__ import unicode_literals`

Python 2.5 support is removed because it doesn't support `from __future__ import unicode_literals` (see http://docs.python.org/2/library/__future__.html)

Cc: @Frozenball, @kevinburke
