### PR TITLE
Display version of pytest and pytest-sugar

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -20,6 +20,9 @@ import re
 from _pytest.terminal import TerminalReporter
 
 
+__version__ = '0.2.4'
+
+
 class TerminalColors:
     HEADER = '\033[95m'
     OKBLUE = '\033[94m'
@@ -205,8 +208,9 @@ class InstafailingTerminalReporter(TerminalReporter):
         self._sessionstarttime = py.std.time.time()
         verinfo = ".".join(map(str, sys.version_info[:3]))
         self.write_line(
-            "Test session starts (%s, %s)" % (
-                sys.platform, verinfo
+            "Test session starts "
+            "(platform: %s, Python %s, pytest %s, pytest-sugar %s)" % (
+                sys.platform, verinfo, pytest.__version__, __version__,
             ), bold=True
         )
         lines = self.config.hook.pytest_report_header(config=self.config)

--- a/setup.py
+++ b/setup.py
@@ -1,10 +1,11 @@
 from setuptools import setup
+from pytest_sugar import __version__
 
 setup(
     name='pytest-sugar',
     description=' py.test plugin that adds instafail, ETA and neat graphics',
     long_description=open("README.rst").read(),
-    version='0.2.4',
+    version=__version__,
     url='http://pivotfinland.com/pytest-sugar/',
     license='BSD',
     author='Teemu, Janne Vanhala',


### PR DESCRIPTION
Define `__version__` in `pytest_sugar.py` and in `setup.py` import it.

And display version info as follows:

```
Test session starts (platform: darwin, Python 3.2.5, pytest 2.5.1, pytest-sugar 0.2.4)
```
