### PR TITLE
Catch ValueError: bad JSON in .pytest-sugar.json

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -52,7 +52,7 @@ class EtaLogger:
             self.collected = json.loads(
                 open(self.settings_path).read()
             )
-        except IOError:
+        except (IOError, ValueError):
             self.collected = {}
         #print "-----------------"
         #print self.collected


### PR DESCRIPTION
It's not that uncommon to end up with invalid JSON in `~/.pytest-sugar.json` -- e.g.: if you hit Ctrl+C while pytest-sugar is running. This prevents it from causing a fatal error that can only be solved by removing `~/.pytest-sugar.json`.
