### PR TITLE
Fine-grained progressbar using more Unicode block chars

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -28,6 +28,7 @@ class TerminalColors:
     OKBLUE = '\033[94m'
     OKGREEN = '\033[92m'
     GRAY = '\033[1;30m'
+    GRAY_BG = '\033[100m'
     WARNING = '\033[93m'
     FAIL = '\033[91m'
     ENDC = '\033[0m'
@@ -249,14 +250,20 @@ class InstafailingTerminalReporter(TerminalReporter):
             ]
             length = 10
             p = float(self.tests_taken) / self.tests_count
-            floored = int(round(p * length))
+
+            floored = int(p * length)
+            rem = int(round((p * length - floored) * 13))
             progressbar = ''
             progressbar += "%i%% " % round(p*100)
-            progressbar += bcolors.OKGREEN
-            progressbar += blocks[0] * floored
+            progressbar += bcolors.OKGREEN + bcolors.GRAY_BG
+            progressbar += blocks[1] * floored
+            if p == 1.0:
+                progressbar += blocks[1]
+            else:
+                progressbar += blocks[14 - rem]
             progressbar += bcolors.ENDC
-            progressbar += bcolors.GRAY
-            progressbar += blocks[0] * (length - floored)
+            progressbar += bcolors.GRAY + bcolors.GRAY_BG
+            progressbar += blocks[1] * (length - floored)
             progressbar += bcolors.ENDC
             return progressbar
 


### PR DESCRIPTION
Hey @Frozenball,

I saw that you had a bunch of different Unicode block characters in a list but you were only using one of them. I figured that you had the idea of using the others someday to show more fine-grained progress. That's what I did here.

This is nice when you're running a lot of slow tests as the percentage done might increment pretty slowly --without this, you won't see much happening on the PR; with this PR you can see the slow, steady progress.
