### PR TITLE
Tweak import order

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -10,11 +10,11 @@ and feel of py.test (e.g. progressbar, show tests that fail instantly).
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals
-import py
-import sys
 import os
+import sys
 import time
 
+import py
 import pytest
 from _pytest.terminal import TerminalReporter
 


### PR DESCRIPTION
`py` is a third-party library so it belongs with `pytest` if we're separating stdlib from 3rd party.

I also alphabetized the stdlib imports cuz why not? :smile: 
