### PR TITLE
Fix incorrect wrapping that fine-grained progress introduced

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -177,7 +177,7 @@ class SugarTerminalReporter(TerminalReporter):
         console_width = self._tw.fullwidth
         num_spaces = console_width - real_string_length(self.current_line)
         full_line = self.current_line + " " * num_spaces
-        full_line = full_line[0:-(len(append_string)-15)] + append_string
+        full_line = full_line[0:-(len(append_string) - 28)] + append_string
         return full_line
 
     def overwrite(self, line):


### PR DESCRIPTION
Sorry, my fine-grained progress commit somehow increased lengths and messed up the calculation with magic number in this line, resulting in this:

![broken](https://f.cloud.github.com/assets/305268/2095832/dbc89312-8ef1-11e3-8bdb-7d45d83adaef.png)

With this PR:

![fixed](https://f.cloud.github.com/assets/305268/2095847/36f7ed5a-8ef2-11e3-9e20-38f03370808f.png)
