### PR TITLE
setup.py: Get version by parsing (not importing) pytest_sugar.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,22 @@
 from setuptools import setup
-from pytest_sugar import __version__
+
+
+# Copied from (and hacked):
+# https://github.com/pypa/virtualenv/blob/develop/setup.py#L42
+def get_version(filename):
+    import os
+    import re
+
+    here = os.path.dirname(os.path.abspath(__file__))
+    f = open(os.path.join(here, filename))
+    version_file = f.read()
+    f.close()
+    version_match = re.search(r"^__version__ = ['\"]([^'\"]*)['\"]",
+                              version_file, re.M)
+    if version_match:
+        return version_match.group(1)
+    raise RuntimeError("Unable to find version string.")
+
 
 setup(
     name='pytest-sugar',
@@ -9,7 +26,7 @@ setup(
         ' instantly).'
     ),
     long_description=open("README.rst").read(),
-    version=__version__,
+    version=get_version('pytest_sugar.py'),
     url='http://pivotfinland.com/pytest-sugar/',
     license='BSD',
     author='Teemu, Janne Vanhala and others',


### PR DESCRIPTION
Because `setup.py` imports `pytest_sugar` which imports `py`, it may try to import `py` before it has been installed. Resulting in:

```
$ mkvirtualenv test
...
$ pip install pytest-sugar
...
  Running setup.py egg_info for package pytest-sugar
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/Users/marca/python/virtualenvs/test/build/pytest-sugar/setup.py", line 2, in <module>
        from pytest_sugar import __version__
      File "pytest_sugar.py", line 17, in <module>
        import py
    ImportError: No module named py
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/marca/python/virtualenvs/test/build/pytest-sugar/setup.py", line 2, in <module>

    from pytest_sugar import __version__

  File "pytest_sugar.py", line 17, in <module>

    import py

ImportError: No module named py
...
```

It happens with `pip install -e` too:

```
$ pip install -e .
Obtaining file:///Users/marca/dev/git-repos/pytest-sugar
  Running setup.py egg_info for package from file:///Users/marca/dev/git-repos/pytest-sugar
    Traceback (most recent call last):
      File "<string>", line 16, in <module>
      File "/Users/marca/dev/git-repos/pytest-sugar/setup.py", line 2, in <module>
        from pytest_sugar import __version__
      File "pytest_sugar.py", line 17, in <module>
        import py
    ImportError: No module named py
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):

  File "<string>", line 16, in <module>

  File "/Users/marca/dev/git-repos/pytest-sugar/setup.py", line 2, in <module>

    from pytest_sugar import __version__

  File "pytest_sugar.py", line 17, in <module>

    import py

ImportError: No module named py
...
```

or even `python setup.py egg_info` (shortest output):

```
$ python setup.py egg_info
Traceback (most recent call last):
  File "setup.py", line 2, in <module>
    from pytest_sugar import __version__
  File "/Users/marca/dev/git-repos/pytest-sugar/pytest_sugar.py", line 17, in <module>
    import py
ImportError: No module named py
```

With this PR:

```
$ mkvirtualenv test
...
$ python setup.py egg_info
running egg_info
writing requirements to pytest_sugar.egg-info/requires.txt
writing pytest_sugar.egg-info/PKG-INFO
writing top-level names to pytest_sugar.egg-info/top_level.txt
writing dependency_links to pytest_sugar.egg-info/dependency_links.txt
writing entry points to pytest_sugar.egg-info/entry_points.txt
reading manifest file 'pytest_sugar.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pytest_sugar.egg-info/SOURCES.txt'
```

Bam. Fixed. This is probably worthy of a new PyPI release. I actually encountered this while trying to get a colleague to use pytest and pytest-sugar and this stopped us dead in our tracks. You and I have never run into this because we love py.test and have pytest and py in our virtualenvs already.
