### PR TITLE
Use the same color in the progress bar and the summary stats for skipped tests

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -311,7 +311,7 @@ class SugarTerminalReporter(TerminalReporter):
 
         if self.count('skipped') > 0:
             self.write_line(
-                TERMINAL_COLORS['fail'] +
+                TERMINAL_COLORS['okblue'] +
                 "   %d skipped" % self.count('skipped') +
                 TERMINAL_COLORS['endc']
             )


### PR DESCRIPTION
I found it confusing to have blue "s" in the progress bar and a red message stating "X skipped" in the summary stats.
I propose to use the same colors, to make it more intuitive.
