### PR TITLE
pytest-cache --lf compatibility

### DIFF
--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -7,3 +7,4 @@ The following people have contributed to pytest-sugar:
 * Mahdi Yusuf
 * dscerri
 * Mounier Florian
+* Michael Howitz

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -62,7 +62,8 @@ def pytest_deselected(items):
     if len(items) > 0:
         pluginmanager = items[0].config.pluginmanager
         terminal_reporter = pluginmanager.getplugin('terminalreporter')
-        terminal_reporter.tests_count -= len(items)
+        if terminal_reporter.tests_count > 0:
+            terminal_reporter.tests_count -= len(items)
 
 
 def pytest_addoption(parser):


### PR DESCRIPTION
pytest-cache calls `pytest_deselected` before `pytest_collection_modifyitems` is called.
But when `pytest_collection_modifyitems` gets called it no longer contains the tests deselected by pytest-cache.
This leads to a negative test count and the exception shown in #37.
