### PR TITLE
GH-42: UnicodeDecodeError - crashline w/ non-ASCII

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -10,6 +10,7 @@ and feel of py.test (e.g. progressbar, show tests that fail instantly).
 :license: BSD, see LICENSE for more details.
 """
 from __future__ import unicode_literals
+import locale
 import os
 import sys
 import time
@@ -310,9 +311,8 @@ class SugarTerminalReporter(TerminalReporter):
             )
             for report in self.reports:
                 if report.outcome == 'failed':
-                    print("      - %s" % (
-                        self._getcrashline(report)
-                    ))
+                    crashline = self._get_decoded_crashline(report)
+                    print( "      - %s" % crashline)
 
         if self.count('skipped') > 0:
             self.write_line(
@@ -327,6 +327,17 @@ class SugarTerminalReporter(TerminalReporter):
                 "   %d deselected" % self.count('deselected') +
                 TERMINAL_COLORS['endc']
             )
+
+    def _get_decoded_crashline(self, report):
+        crashline = self._getcrashline(report)
+
+        if hasattr(crashline, 'decode'):
+            encoding = locale.getpreferredencoding()
+            try:
+                crashline = crashline.decode(encoding)
+            except UnicodeDecodeError:
+                encoding = 'utf-8'
+                crashline = crashline.decode(encoding, errors='replace')
 
     def summary_failures(self):
         # Prevent failure summary from being shown since we already

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -41,27 +41,29 @@ class TestInstafailingTerminalReporter(object):
             """
         )
         result = testdir.runpytest(*option.args)
-        if option.verbose:
-            result.stdout.fnmatch_lines([
-                "* test_func *",
-                "    def test_func():",
-                ">       assert 0",
-                "E       assert 0",
-            ])
-        elif option.quiet:
-            result.stdout.fnmatch_lines([
-                "* test_func *",
-                "    def test_func():",
-                ">       assert 0",
-                "E       assert 0",
-            ])
-        else:
-            result.stdout.fnmatch_lines([
-                "* test_func *",
-                "    def test_func():",
-                ">       assert 0",
-                "E       assert 0",
-            ])
+        result.stdout.fnmatch_lines([
+            "* test_func *",
+            "    def test_func():",
+            ">       assert 0",
+            "E       assert 0",
+        ])
+
+    def test_fail_unicode_crashline(self, testdir, option):
+        testdir.makepyfile(
+            """
+            # -*- coding: utf-8 -*-
+            import pytest
+            def test_func():
+                assert b'hello' == b'Bj\\xc3\\xb6rk Gu\\xc3\\xb0mundsd\\xc3\\xb3ttir'
+            """
+        )
+        result = testdir.runpytest(*option.args)
+        result.stdout.fnmatch_lines([
+            "* test_func *",
+            "    def test_func():",
+            ">       assert * == *",
+            "E       assert * == *",
+        ])
 
     def test_fail_fail(self, testdir, option):
         testdir.makepyfile(


### PR DESCRIPTION
Fixes: GH-42

Before:

```
❯ py.test _test_fail_unicode.py
Test session starts (platform: darwin, Python 2.7.6, pytest 2.6.4, pytest-sugar 0.3.5)
plugins: sugar


――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    def test():
>       assert u'jello' == u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
E       assert 'jello' == 'Björk Guðmundsdóttir'
E         - jello
E         + Björk Guðmundsdóttir

_test_fail_unicode.py:4: AssertionError

   _test_fail_unicode.py ⨯                                                                                                                                  100% ▉▉▉▉▉▉▉▉▉▉▉

Results (0.01s):
   1 failed
Traceback (most recent call last):
  File "/Users/marca/python/virtualenvs/pytest-sugar/bin/py.test", line 9, in <module>
    load_entry_point('pytest==2.6.4', 'console_scripts', 'py.test')()
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/config.py", line 41, in main
    return config.hook.pytest_cmdline_main(config=config)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 413, in __call__
    return self._docall(methods, kwargs)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 424, in _docall
    res = mc.execute()
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 315, in execute
    res = method(**kwargs)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/main.py", line 116, in pytest_cmdline_main
    return wrap_session(config, _main)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/main.py", line 109, in wrap_session
    exitstatus=session.exitstatus)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 413, in __call__
    return self._docall(methods, kwargs)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 424, in _docall
    res = mc.execute()
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/core.py", line 315, in execute
    res = method(**kwargs)
  File "/Users/marca/python/virtualenvs/pytest-sugar/lib/python2.7/site-packages/_pytest/terminal.py", line 360, in pytest_sessionfinish
    self.summary_stats()
  File "/Users/marca/dev/git-repos/pytest-sugar/pytest_sugar.py", line 314, in summary_stats
    self._getcrashline(report)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 86: ordinal not in range(128)
```

After:

```
❯ py.test _test_fail_unicode.py
Test session starts (platform: darwin, Python 2.7.6, pytest 2.6.4, pytest-sugar 0.3.5)
plugins: sugar


――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― test ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――

    def test():
>       assert u'jello' == u'Bj\xf6rk Gu\xf0mundsd\xf3ttir'
E       assert 'jello' == 'Björk Guðmundsdóttir'
E         - jello
E         + Björk Guðmundsdóttir

_test_fail_unicode.py:4: AssertionError

   _test_fail_unicode.py ⨯                                                                                                                                  100% ▉▉▉▉▉▉▉▉▉▉▉

Results (0.02s):
   1 failed
      - /Users/marca/dev/git-repos/pytest-sugar/_test_fail_unicode.py:4: assert 'jello' == 'Björk Guðmundsdóttir'
```
