### PR TITLE
PyPI troves classifiers still in Alpha

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     platforms='any',
     install_requires=['pytest>=2.9', 'termcolor>=1.1.0', 'packaging>=14.1'],
     classifiers=[
-        'Development Status :: 3 - Alpha',
+        'Development Status :: 5 - Production/Stable',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',
         'Operating System :: POSIX',


### PR DESCRIPTION
I would consider upgrading to Production/Stable with regards to how many people rely on it.