### PR TITLE
Do not override pytest's report_collect

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -225,9 +225,6 @@ class SugarTerminalReporter(TerminalReporter):
         self.current_line_nums = {}
         self.current_line_num = 0
 
-    def report_collect(self, final=False):
-        pass
-
     def pytest_collectreport(self, report):
         TerminalReporter.pytest_collectreport(self, report)
         if report.location[0]:


### PR DESCRIPTION
With 3.10.0 it will write "collecting ..." now always, and I think it is
good to see progress here.
This uses to be rather slow (because it printed a lot), which has been
fixed (only prints every 0.5s).

Ref: https://github.com/pytest-dev/pytest/pull/4225