### PR TITLE
Proper fix for double colon issue

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -368,17 +368,10 @@ class SugarTerminalReporter(TerminalReporter):
         basename = os.path.basename(fspath)
         if print_filename:
             if self.showlongtestinfo:
-                test_location = report.location[0]
-                test_name = report.location[2]
+                test_location, _, test_name = report.nodeid.partition('::')
             else:
                 test_location = fspath[0:-len(basename)]
                 test_name = fspath[-len(basename):]
-            if test_location:
-                pass
-                # only replace if test_location is not empty, if it is,
-                # test_name contains the filename
-                # FIXME: This doesn't work.
-                # test_name = test_name.replace('.', '::')
             self.current_lines[path] = (
                 " " +
                 colored(test_location, THEME['path']) +

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -473,38 +473,43 @@ class TestTerminalReporter(object):
             output
         )
 
-    # def test_verbose_has_double_colon_with_class(self, testdir):
-    #     testdir.makepyfile(
-    #         """
-    #         class TestTrue:
+    def test_verbose_has_double_colon_with_class(self, testdir):
+        testdir.makepyfile(
+            """
+            class TestTrue:
 
-    #             def test_true(self):
-    #                 assert True
-    #         """
-    #     )
-    #     output = testdir.runpytest(
-    #         '--force-sugar', '--verbose'
-    #     ).stdout.str()
+                def test_true(self):
+                    assert True
+            """
+        )
+        output = testdir.runpytest(
+            '--force-sugar', '--verbose'
+        ).stdout.str()
 
-    #     test_name = (
-    #         'test_verbose_has_double_colon_with_class.py::TestTrue::test_true')
-    #     assert test_name in strip_colors(output)
+        # see: https://github.com/pytest-dev/pytest/commit/ac8b9c6e9dbb66114a1c3f79cd1fdeb0b2b2c54d
+        if LooseVersion(pytest.__version__) < LooseVersion('4.0'):
+            test_name = (
+                'test_verbose_has_double_colon_with_class.py::TestTrue::()::test_true')
+        else:
+            test_name = (
+                'test_verbose_has_double_colon_with_class.py::TestTrue::test_true')
+        assert test_name in strip_colors(output)
 
-    # def test_not_verbose_no_double_colon_filename(self, testdir):
-    #     testdir.makepyfile(
-    #         """
-    #         class TestTrue:
+    def test_not_verbose_no_double_colon_filename(self, testdir):
+        testdir.makepyfile(
+            """
+            class TestTrue:
 
-    #             def test_true(self):
-    #                 assert True
-    #         """
-    #     )
-    #     output = testdir.runpytest(
-    #         '--force-sugar'
-    #     ).stdout.str()
+                def test_true(self):
+                    assert True
+            """
+        )
+        output = testdir.runpytest(
+            '--force-sugar'
+        ).stdout.str()
 
-    #     test_name = 'test_not_verbose_no_double_colon_filename.py'
-    #     assert test_name in strip_colors(output)
+        test_name = 'test_not_verbose_no_double_colon_filename.py'
+        assert test_name in strip_colors(output)
 
     def test_xdist(self, testdir):
         pytest.importorskip("xdist")

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -486,13 +486,17 @@ class TestTerminalReporter(object):
             '--force-sugar', '--verbose'
         ).stdout.str()
 
-        # see: https://github.com/pytest-dev/pytest/commit/ac8b9c6e9dbb66114a1c3f79cd1fdeb0b2b2c54d
+        # see: https://github.com/pytest-dev/pytest/commit/ac8b9c6e9dbb66114a1c3f79cd1fdeb0b2b2c54d  # noqa
         if LooseVersion(pytest.__version__) < LooseVersion('4.0'):
             test_name = (
-                'test_verbose_has_double_colon_with_class.py::TestTrue::()::test_true')
+                'test_verbose_has_double_colon_with_class.py::'
+                'TestTrue::()::test_true'
+            )
         else:
             test_name = (
-                'test_verbose_has_double_colon_with_class.py::TestTrue::test_true')
+                'test_verbose_has_double_colon_with_class.py::'
+                'TestTrue::test_true'
+            )
         assert test_name in strip_colors(output)
 
     def test_not_verbose_no_double_colon_filename(self, testdir):


### PR DESCRIPTION
Test case names in verbose output are no longer correct node ids, so can't be copied to clipboard and passed as pytest command argument. This pull request will keep #153 fixed and bring back correct test case names.
