### PR TITLE
removed the dot from the pytest command

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 When reporting an issue, include a way to reproduce the bug. For example:
 
-#### Command used to run py.test
-````py.test test_example.py````
+#### Command used to run pytest
+````pytest test_example.py````
 
 #### Test file
 ````python

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![](https://travis-ci.org/Frozenball/pytest-sugar.svg?branch=master)](https://travis-ci.org/Frozenball/pytest-sugar) ![](https://img.shields.io/pypi/v/pytest-sugar.svg)
 
-pytest-sugar is a plugin for [py.test](http://pytest.org) that shows
+pytest-sugar is a plugin for [pytest](http://pytest.org) that shows
 failures and errors instantly and shows a progress bar.
 
 ![](http://pivotfinland.com/pytest-sugar/img/video.gif)
@@ -24,15 +24,15 @@ To install pytest-sugar:
 
 Then run your tests with:
 
-    $ py.test
+    $ pytest
 
 If you would like more detailed output (one test per line), then you may use the verbose option:
 
-    $ py.test --verbose
+    $ pytest --verbose
 
 If you would like to run tests without pytest-sugar, use:
 
-    $ py.test -p no:sugar
+    $ pytest -p no:sugar
 
 ## Running on Windows
 

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -3,8 +3,8 @@
 pytest_sugar
 ~~~~~~~~~~~~
 
-py.test is a plugin for py.test that changes the default look
-and feel of py.test (e.g. progressbar, show tests that fail instantly).
+pytest-sugar is a plugin for pytest that changes the default look
+and feel of pytest (e.g. progressbar, show tests that fail instantly).
 
 :copyright: see LICENSE for details
 :license: BSD, see LICENSE for more details.


### PR DESCRIPTION
removed the dot from the pytest command.

As of version 3.0, the dot is no longer needed in the pytest command:

https://docs.pytest.org/en/latest/changelog.html#id836