### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # pytest-sugar
 
-[![](https://travis-ci.org/Frozenball/pytest-sugar.svg?branch=master)](https://travis-ci.org/Frozenball/pytest-sugar) ![](https://img.shields.io/pypi/v/pytest-sugar.svg)
+[![Build status](https://travis-ci.org/Teemu/pytest-sugar.svg?branch=master)](https://travis-ci.org/Teemu/pytest-sugar)
+[![Pypi version](https://img.shields.io/pypi/v/pytest-sugar.svg)](https://pypi.org/project/pytest-sugar/)
 
 pytest-sugar is a plugin for [py.test](http://pytest.org) that shows
 failures and errors instantly and shows a progress bar.
 
-![](http://pivotfinland.com/pytest-sugar/img/video.gif)
+![Demo](http://pivotfinland.com/pytest-sugar/img/video.gif)
 
 ## Requirements
 
@@ -20,20 +21,20 @@ You will need the following prerequisites in order to use pytest-sugar:
 
 To install pytest-sugar:
 
-    $ pip install pytest-sugar
+    pip install pytest-sugar
 
 Then run your tests with:
 
-    $ py.test
+    py.test
 
 If you would like more detailed output (one test per line), then you may use the verbose option:
 
-    $ py.test --verbose
+    py.test --verbose
 
 If you would like to run tests without pytest-sugar, use:
 
-    $ py.test -p no:sugar
+    py.test -p no:sugar
 
 ## Running on Windows
 
-If you are seeing gibberish, you might want to try changing charset and fonts. See [this comment]( https://github.com/Frozenball/pytest-sugar/pull/49#issuecomment-146567670) for more details.
+If you are seeing gibberish, you might want to try changing charset and fonts. See [this comment]( https://github.com/Teemu/pytest-sugar/pull/49#issuecomment-146567670) for more details.


### PR DESCRIPTION
* Travis badge points to actual build
* Updated code snippets according to [this](https://github.com/DavidAnson/markdownlint/blob/master/doc/Rules.md#md014---dollar-signs-used-before-commands-without-showing-output)
* Add alt-text to the demo and update link to github issue

This should also solve broken links at https://pypi.org/project/pytest-sugar/ provided an update is issued.
btw: thanks for a nice plugin