### PR TITLE
Update to pytest 5.4.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,12 @@ matrix:
       python: 3.4
     - env: TOXENV=py35-pytest39-supported-xdist
       python: 3.5
-    - env: TOXENV=py36-pytest40-supported-xdist
+    - env: TOXENV=py36-pytest40-supported-xdist-pinned-attrs
       python: 3.6
 
-    - env: TOXENV=py37-pytest41-supported-xdist
-    - env: TOXENV=py37-pytest42-supported-xdist
-    - env: TOXENV=py37-pytest42-unsupported-xdist-rerunfailures
+    - env: TOXENV=py37-pytest41-supported-xdist-pinned-attrs
+    - env: TOXENV=py37-pytest42-supported-xdist-pinned-attrs
+    - env: TOXENV=py37-pytest42-unsupported-xdist-rerunfailures-pinned-attrs
     - env: TOXENV=py37-pytest46-supported-xdist
 
     # Latest pytest.

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,10 @@ matrix:
     - env: TOXENV=py37-pytest41-supported-xdist
     - env: TOXENV=py37-pytest42-supported-xdist
     - env: TOXENV=py37-pytest42-unsupported-xdist-rerunfailures
+    - env: TOXENV=py37-pytest46-supported-xdist
 
     # Latest pytest.
-    - env: TOXENV=py37-pytest46-supported-xdist
+    - env: TOXENV=py37-pytest54-supported-xdist
 
     - env: TOXENV=qa
 install: pip install -U tox

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -211,7 +211,6 @@ def pytest_report_teststatus(report):
 class SugarTerminalReporter(TerminalReporter):
     def __init__(self, reporter):
         TerminalReporter.__init__(self, reporter.config)
-        self.writer = self._tw
         self.paths_left = []
         self.tests_count = 0
         self.tests_taken = 0
@@ -339,14 +338,14 @@ class SugarTerminalReporter(TerminalReporter):
     def overwrite(self, line, rel_line_num):
         # Move cursor up rel_line_num lines
         if rel_line_num > 0:
-            self.writer.write("\033[%dA" % rel_line_num)
+            self.write("\033[%dA" % rel_line_num)
 
         # Overwrite the line
-        self.writer.write("\r%s" % line)
+        self.write("\r%s" % line)
 
         # Return cursor to original line
         if rel_line_num > 0:
-            self.writer.write("\033[%dB" % rel_line_num)
+            self.write("\033[%dB" % rel_line_num)
 
     def get_max_column_for_test_status(self):
         return (
@@ -389,7 +388,7 @@ class SugarTerminalReporter(TerminalReporter):
         else:
             self.current_lines[path] = " " * (2 + len(fspath))
         self.current_line_nums[path] = self.current_line_num
-        self.writer.write("\r\n")
+        self.write("\r\n")
 
     def reached_last_column_for_test_status(self, report):
         len_line = real_string_length(

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -547,7 +547,7 @@ class TestTerminalReporter(object):
                     \"\"\"
             """
         )
-        result = testdir.runpytest('--force-sugar', '--doctest-module')
+        result = testdir.runpytest('--force-sugar', '--doctest-modules')
 
         assert result.ret == 1, result.stderr.str()
 
@@ -567,7 +567,7 @@ class TestTerminalReporter(object):
                 raise NotImplementedError
             """
         )
-        result = testdir.runpytest('--force-sugar', '--doctest-module')
+        result = testdir.runpytest('--force-sugar', '--doctest-modules')
 
         assert result.ret == 1, result.stderr.str()
         result.stdout.fnmatch_lines([

--- a/tox.ini
+++ b/tox.ini
@@ -10,21 +10,23 @@ deps =
     pytest38: pytest>=3.8,<3.9
     pytest39: pytest>=3.9,<3.10
     pytest310: pytest>=3.10,<3.11
-    pytest40: pytest>=4.0,<4.1,attrs<=19.3.1
-    pytest41: pytest>=4.1,<4.2,attrs<=19.3.1
-    pytest42: pytest>=4.2,<4.3,attrs<=19.3.1
+    pytest40: pytest>=4.0,<4.1
+    pytest41: pytest>=4.1,<4.2
+    pytest42: pytest>=4.2,<4.3
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6
     pytest46: pytest>=4.6,<4.7
     pytest54: pytest>=5.4,<5.5
     termcolor>=1.1.0
+    pinned-attrs: attrs{env:_TOX_SUGAR_ATTRS_VERSION:>=19.1}
     supported-xdist: pytest-xdist{env:_TOX_SUGAR_XDIST_VERSION:>=1.14}
     unsupported-xdist: pytest-xdist<1.14
     rerunfailures: pytest-rerunfailures
 setenv =
     # pytest-xdist >= 1.28 requires pytest 4.4
     pytest{36,37,38,39,310,40,41,42,43}: _TOX_SUGAR_XDIST_VERSION=>=1.14,<1.28
+    pytest{40,41,42}: _TOX_SUGAR_ATTRS_VERSION=>=19.1,<19.2
 commands =
     pytest --cov --cov-config=.coveragerc {posargs:test_sugar.py}
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ deps =
     pytest38: pytest>=3.8,<3.9
     pytest39: pytest>=3.9,<3.10
     pytest310: pytest>=3.10,<3.11
-    pytest40: pytest>=4.0,<4.1, attrs==19.3.1
-    pytest41: pytest>=4.1,<4.2, attrs==19.3.1
-    pytest42: pytest>=4.2,<4.3, attrs==19.3.1
+    pytest40: pytest>=4.0,<4.1 attrs<=19.3.1
+    pytest41: pytest>=4.1,<4.2 attrs<=19.3.1
+    pytest42: pytest>=4.2,<4.3 attrs<=19.3.1
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6

--- a/tox.ini
+++ b/tox.ini
@@ -19,14 +19,13 @@ deps =
     pytest46: pytest>=4.6,<4.7
     pytest54: pytest>=5.4,<5.5
     termcolor>=1.1.0
-    pinned-attrs: attrs{env:_TOX_SUGAR_ATTRS_VERSION:>=19.1}
     supported-xdist: pytest-xdist{env:_TOX_SUGAR_XDIST_VERSION:>=1.14}
     unsupported-xdist: pytest-xdist<1.14
     rerunfailures: pytest-rerunfailures
+    pinned-attrs: attrs<19.2
 setenv =
     # pytest-xdist >= 1.28 requires pytest 4.4
     pytest{36,37,38,39,310,40,41,42,43}: _TOX_SUGAR_XDIST_VERSION=>=1.14,<1.28
-    pytest{40,41,42}: _TOX_SUGAR_ATTRS_VERSION=>=19.1,<19.2
 commands =
     pytest --cov --cov-config=.coveragerc {posargs:test_sugar.py}
 

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,9 @@ deps =
     pytest38: pytest>=3.8,<3.9
     pytest39: pytest>=3.9,<3.10
     pytest310: pytest>=3.10,<3.11
-    pytest40: pytest>=4.0,<4.1 attrs<=19.3.1
-    pytest41: pytest>=4.1,<4.2 attrs<=19.3.1
-    pytest42: pytest>=4.2,<4.3 attrs<=19.3.1
+    pytest40: pytest>=4.0,<4.1,attrs<=19.3.1
+    pytest41: pytest>=4.1,<4.2,attrs<=19.3.1
+    pytest42: pytest>=4.2,<4.3,attrs<=19.3.1
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6

--- a/tox.ini
+++ b/tox.ini
@@ -10,13 +10,14 @@ deps =
     pytest38: pytest>=3.8,<3.9
     pytest39: pytest>=3.9,<3.10
     pytest310: pytest>=3.10,<3.11
-    pytest40: pytest>=4.0,<4.1
-    pytest41: pytest>=4.1,<4.2
-    pytest42: pytest>=4.2,<4.3
+    pytest40: pytest>=4.0,<4.1, attrs==19.3.1
+    pytest41: pytest>=4.1,<4.2, attrs==19.3.1
+    pytest42: pytest>=4.2,<4.3, attrs==19.3.1
     pytest43: pytest>=4.3,<4.4
     pytest44: pytest>=4.4,<4.5
     pytest45: pytest>=4.5,<4.6
     pytest46: pytest>=4.6,<4.7
+    pytest54: pytest>=5.4,<5.5
     termcolor>=1.1.0
     supported-xdist: pytest-xdist{env:_TOX_SUGAR_XDIST_VERSION:>=1.14}
     unsupported-xdist: pytest-xdist<1.14


### PR DESCRIPTION
This PR uses `self.write()` instead of `self.writer.write()` to follow new `pytest 5.4.0` API and avoid using `self.writer` directly which has been deprecated.

Closes https://github.com/Teemu/pytest-sugar/issues/187