### PR TITLE
Get test count from collection_finish hook over runtestloop

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -73,7 +73,7 @@ def flatten(l):
             yield x
 
 
-def pytest_runtestloop(session):
+def pytest_collection_finish(session):
     reporter = session.config.pluginmanager.getplugin('terminalreporter')
     if reporter:
         reporter.tests_count = len(session.items)

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -64,8 +64,8 @@ PROGRESS_BAR_BLOCKS = [
 ]
 
 
-def flatten(l):
-    for x in l:
+def flatten(iterable):
+    for x in iterable:
         if isinstance(x, (list, tuple)):
             for y in flatten(x):
                 yield y


### PR DESCRIPTION
Using runtestloop hook to count tests can easily conflict with other plugins that override the default runtestloop behavior (e.g.  in pytest_mproc or pytest_xdist that do distributed testing).  Using the collection hooks -- in this case collect_finish hook seems more approriate overall anyway(?)