### PR TITLE
Fix regression with pytest 5.4 and line number report for doctests

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -64,8 +64,8 @@ PROGRESS_BAR_BLOCKS = [
 ]
 
 
-def flatten(l):
-    for x in l:
+def flatten(seq):
+    for x in seq:
         if isinstance(x, (list, tuple)):
             for y in flatten(x):
                 yield y
@@ -589,8 +589,8 @@ class SugarTerminalReporter(TerminalReporter):
         return crashline
 
     def _get_lineno_from_report(self, report):
-        # Doctest failure reports changed the attribute where longrepr were stored in pytest>3.10
-        # to reprlocation_lines, a list of (ReprFileLocation, lines)
+        # Doctest failures in pytest>3.10 are stored in
+        # reprlocation_lines, a list of (ReprFileLocation, lines)
         try:
             location, lines = report.longrepr.reprlocation_lines[0]
             return location.lineno

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -238,6 +238,7 @@ class SugarTerminalReporter(TerminalReporter):
             self.print_failure(report)
 
     def pytest_sessionstart(self, session):
+        self._session = session
         self._sessionstarttime = py.std.time.time()
         verinfo = ".".join(map(str, sys.version_info[:3]))
         self.write_line(

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -531,14 +531,7 @@ class SugarTerminalReporter(TerminalReporter):
                 else:
                     path = os.path.dirname(report.location[0])
                     name = os.path.basename(report.location[0])
-                    # Doctest failure reports have lineno=None at least up to
-                    # pytest==3.0.7, but it is available via longrepr object.
-                    try:
-                        lineno = report.longrepr.reprlocation.lineno
-                    except AttributeError:
-                        lineno = report.location[1]
-                        if lineno is not None:
-                            lineno += 1
+                    lineno = self._get_lineno_from_report(report)
                     crashline = '%s%s%s:%s %s' % (
                         colored(path, THEME['path']),
                         '/' if path else '',
@@ -594,6 +587,24 @@ class SugarTerminalReporter(TerminalReporter):
                 crashline = crashline.decode(encoding, errors='replace')
 
         return crashline
+
+    def _get_lineno_from_report(self, report):
+        # Doctest failure reports changed the attribute where longrepr were stored in pytest>3.10
+        # to reprlocation_lines, a list of (ReprFileLocation, lines)
+        try:
+            location, lines = report.longrepr.reprlocation_lines[0]
+            return location.lineno
+        except AttributeError:
+            pass
+        # Doctest failure reports have lineno=None at least up to
+        # pytest==3.0.7, but it is available via longrepr object.
+        try:
+            return report.longrepr.reprlocation.lineno
+        except AttributeError:
+            lineno = report.location[1]
+            if lineno is not None:
+                lineno += 1
+            return lineno
 
     def summary_failures(self):
         # Prevent failure summary from being shown since we already

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -551,10 +551,6 @@ class TestTerminalReporter(object):
 
         assert result.ret == 1, result.stderr.str()
 
-    @pytest.mark.skipif(
-      LooseVersion(pytest.__version__) >= LooseVersion('3.5'),
-      reason='Temporarily skipping until #134'
-    )
     def test_doctest_lineno(self, testdir):
         """ Test location reported for doctest-modules """
 

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
 import pytest
 import re
-from distutils.version import LooseVersion
 from pytest_sugar import strip_colors
 
 pytest_plugins = "pytester"


### PR DESCRIPTION
Hi!

While working on #194, I came across and fixed #134 as well. 👍 

* Fix line number report for doctests in pytest>=3.10
* Fix compatibility with pytest 5.4

Fix #194
Fix #134
Fix #180
Close pytest-dev/pytest#7287