### PR TITLE
Fix for pytest_sugar.py:67:13: Flake8 error

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -64,8 +64,8 @@ PROGRESS_BAR_BLOCKS = [
 ]
 
 
-def flatten(l):
-    for x in l:
+def flatten(items):
+    for x in items:
         if isinstance(x, (list, tuple)):
             for y in flatten(x):
                 yield y


### PR DESCRIPTION
Fix for pytest_sugar.py:67:13: E741 ambiguous variable name 'l'