### PR TITLE
Remove deprecation warning from using distutils

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -165,9 +165,13 @@ def pytest_configure(config):
         except ImportError:
             pass
         else:
-            from distutils.version import LooseVersion
-            xdist_version = LooseVersion(xdist.__version__)
-            if xdist_version >= LooseVersion('1.14'):
+            try:
+                from packaging.version import Version
+            except ModuleNotFoundError:
+                from distutils.version import LooseVersion as Version
+
+            xdist_version = Version(xdist.__version__)
+            if xdist_version >= Version('1.14'):
                 config.pluginmanager.register(DeferredXdistPlugin())
 
     if IS_SUGAR_ENABLED and not getattr(config, 'slaveinput', None):


### PR DESCRIPTION
Using distutils is deprecated and it triggers a DeprecationWarning in python
3.10 which is output on stderr and then makes some Ubuntu/Debian packages
autopkgtests fail.

Signed-off-by: Alexandre Ghiti <alexandre.ghiti@canonical.com>