### PR TITLE
Handle colors for reruns from pytest-rerunfailures. Closes #139

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -482,6 +482,8 @@ class SugarTerminalReporter(TerminalReporter):
                         markup = {'green': True}
                     elif report.skipped:
                         markup = {'yellow': True}
+                    elif hasattr(report, "rerun") and isinstance(report.rerun, int):
+                        markup = {'blue': True}
                 line = self._locationline(str(report.fspath), *report.location)
                 if hasattr(report, 'node'):
                     self._tw.write("\r\n")


### PR DESCRIPTION
Fixes the `UnboundLocalError: local variable 'markup' referenced before assignment` error reported in #139 and #225

Manually tested this a few different ways. I'm honestly not sure how to write a test for this.