### PR TITLE
Proposed release 0.9.5

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,13 @@ Changelog
 
 A list of changes between each release.
 
+0.9.5 (2022-04-12)
+^^^^^^^^^^^^^^^^^^^
+
+- Fix distutils deprecation warning (thanks @tgagor)
+- Fix incompatibility with pytest-timeout (thanks @graingert)
+- Update pytest naming convention in documentation (thanks @avallbona)
+
 0.9.4 (2020-07-06)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -28,7 +28,7 @@ import pytest
 from _pytest.terminal import TerminalReporter
 
 
-__version__ = '0.9.4'
+__version__ = '0.9.5'
 
 LEN_RIGHT_MARGIN = 0
 LEN_PROGRESS_PERCENTAGE = 5


### PR DESCRIPTION
This PR attempts to follow the process for the last release you did, for 0.9.4: https://github.com/Teemu/pytest-sugar/commit/92ae9dee9f76af01a64d29de5ab07ef33fc5a15b, under the assumption that you (perfectly reasonably) don't have much time to spend on this project. Feel free to disregard.

Motivation: the distutils deprecation change is rather noisy without the patch, and has been patched into the https://github.com/conda-forge/pytest-sugar-feedstock/pull/14 release - but it'd be much cleaner to have an actual official release to base this off, and for pypi. Obviously this would only mark the repository and wouldn't e.g. update tags or the pypi distribution, which would be work for you.[^1]


For release, this PR uses the current state of the master branch. The main changes merged [since last time](https://github.com/Teemu/pytest-sugar/compare/92ae9dee9f76af01a64d29de5ab07ef33fc5a15b...master) appear to be, #178 (rename front README from py.test), #203 (fix crash with pytest-timeout) and #230 (distutils deprecation). I added these to the CHANGES.rst. In addition, there was merged #204 (fix ci) and #206 (add github link to pypi), some changes to test harness dependency resolution, and adding the code of conduct, - which didn't seem to reach the threshold of "user-facing" change listing.


[^1]: I am happy to do this pypi upload for this release if you wanted to add me to the project maintainers - I am one of my organisation's package maintainers - https://pypi.org/user/ndevenish/; but obviously it's unreasonable to drop this sentence here and expect anything.