### PR TITLE
Clean up CI configuration

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -12,48 +12,20 @@ on:
 
 jobs:
   test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false # run all tests anyway
       matrix:
         include:
-          - toxenv: pytest30
-            python: 2.7
-          - toxenv: py27-pytest36-supported-xdist
-            python: 2.7
-          - toxenv: py27-pytest37-unsupported-xdist
-            python: 2.7
-
-          # fixme: not supported by actions/setup-python
-          # - toxenv: py34-pytest38-supported-xdist
-          #   python: 3.4
-
-          - toxenv: py35-pytest39-supported-xdist
-            python: 3.5
-          - toxenv: py36-pytest40-supported-xdist-pinned-attrs
-            python: 3.6
-
-          - toxenv: py37-pytest41-supported-xdist-pinned-attrs
-            python: 3.7
-          - toxenv: py37-pytest42-supported-xdist-pinned-attrs
-            python: 3.7
-          # fixme: hungs build or fails
-          # - toxenv: py37-pytest42-unsupported-xdist-rerunfailures-pinned-attrs
-          #   python: 3.7
-          - toxenv: py37-pytest46-supported-xdist
-            python: 3.7
-
-          - toxenv: py37-pytest54-supported-xdist
-            python: 3.7
-          - toxenv: py38-pytest54-supported-xdist
+          # Python 3.8 && Pytest 6.2
+          - toxenv: py38-pytest62-supported-xdist
             python: 3.8
 
-          # Latest pytest.
-          - toxenv: py37-pytest60-supported-xdist
-            python: 3.7
-          - toxenv: py38-pytest60-supported-xdist
-            python: 3.8
+          # Latest Python & Pytest
+          - toxenv: py311-pytest_latest-supported-xdist
+            python: 3.11
 
+          # QA
           - toxenv: qa
             python: 3.8
     steps:

--- a/README.md
+++ b/README.md
@@ -54,10 +54,8 @@ pytest faketests
 
 You will need the following prerequisites in order to use pytest-sugar:
 
-- Python 2.7, 3.4 or newer
-- pytest 2.9.0 or newer
-- pytest-xdist 1.14 or above if you want the progress bar to work while running
-  tests in parallel
+- Python 3.8 or newer
+- pytest 6.2 or newer
 
 ## Running on Windows
 

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -163,7 +163,7 @@ def real_string_length(string):
 IS_SUGAR_ENABLED = False
 
 
-@pytest.mark.trylast
+@pytest.hookimpl(trylast=True)
 def pytest_configure(config):
     global IS_SUGAR_ENABLED
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py{27,34,35,36,37,py}-pytest39-{supported,unsupported}-xdist
+envlist = py{38,311,py}-pytest_latest
           qa
 requires = virtualenv>=20.0.31
 
@@ -9,50 +9,14 @@ install_command =
   {py34,.tox}: python -m pip install {opts} {packages}
   !{py34,.tox}: python -m pip install --use-feature=fast-deps {opts} {packages}
 deps =
-    pytest36: pytest~=3.6.4
-    pytest37: pytest~=3.7.4
-    pytest38: pytest~=3.8.2
-    pytest39: pytest~=3.9.3
-    pytest310: pytest~=3.10.1
-    pytest40: pytest~=4.0.2
-    pytest41: pytest~=4.1.1
-    pytest42: pytest~=4.2.1
-    pytest43: pytest~=4.3.1
-    pytest44: pytest~=4.4.2
-    pytest45: pytest~=4.5.0
-    pytest46: pytest~=4.6.11
-    pytest54: pytest~=5.4.3
-    pytest60: pytest~=6.0.1
+    pytest62: pytest~=6.2.5
+    pytest_latest: pytest
     termcolor>=1.1.0
-    supported-xdist: pytest-xdist{env:_TOX_SUGAR_XDIST_VERSION:>=1.14}
-    supported-xdist: pytest-forked{env:_TOX_SUGAR_FORKED_VERSION:>=1.3.0}
-    pytest-cov{env:_TOX_SUGAR_COV_VERSION:>=2.10.0}
-    unsupported-xdist: pytest-xdist<1.14
-    rerunfailures: pytest-rerunfailures
-    pinned-attrs: attrs<19.2
-setenv =
-    # pytest-xdist >= 1.28 requires pytest 4.4
-    pytest{36,37,38,39,310,40,41,42,43}: _TOX_SUGAR_XDIST_VERSION=>=1.14,<1.28
-
-    # pytest-cov >= 2.10 requires pytest>=4.6
-    !py34-pytest{36,37,38,39,310,40,41,42,43,45}: _TOX_SUGAR_COV_VERSION=~=2.9.0
-    # pytest-cov >= 2.9.0 requires python>=3.4 or ~=2.7.0
-    py34: _TOX_SUGAR_COV_VERSION=~=2.8.1
-
-    # pytest-forked >= 1.3.0 requires pytest>=3.10
-    !py34-pytest{36,37,38,39}: _TOX_SUGAR_FORKED_VERSION=~=1.2.0
-    # pytest-forked >= 1.2.0 requires python>=3.4 or ~=2.7.0
-    py34: _TOX_SUGAR_FORKED_VERSION=~=1.1.3
+    supported-xdist: pytest-xdist
+    supported-xdist: pytest-forked
+    pytest-cov
 commands =
     pytest --cov --cov-config=.coveragerc {posargs:test_sugar.py}
-
-# Oldest supported (testable) version.
-[testenv:pytest30]
-deps =
-    pytest~=3.0.7
-    pytest-xdist<1.25
-    pytest-forked<0.3
-    pytest-cov<2.6.1
 
 [testenv:qa]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py{38,311,py}-pytest_latest
+envlist = py{38,311,py}-pytest_latest-supported-xdist
           qa
 requires = virtualenv>=20.0.31
 

--- a/tox.ini
+++ b/tox.ini
@@ -5,9 +5,7 @@ envlist = py{38,311,py}-pytest_latest
 requires = virtualenv>=20.0.31
 
 [testenv]
-install_command =
-  {py34,.tox}: python -m pip install {opts} {packages}
-  !{py34,.tox}: python -m pip install --use-feature=fast-deps {opts} {packages}
+install_command = python -m pip install --use-feature=fast-deps {opts} {packages}
 deps =
     pytest62: pytest~=6.2.5
     pytest_latest: pytest


### PR DESCRIPTION
I'm cleaning up our CI pipeline a bit. To keep sanity, I propose that we change our minimum support to:

- We support Python 3.8 & newer (Ubuntu 20.04 LTS -- my current guideline has always been to support last two LTS)
- We support pytest 6.2.0 & newer (that's from 2020 -- honestly I think it could be OK to drop support for all but the latest. Not sure what backward compatibilities pytest has nowadays)