### PR TITLE
Automate PyPI package releases via AutoPub

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -39,3 +39,34 @@ jobs:
         env:
           TOXENV: ${{ matrix.toxenv }}
         run: tox
+
+  deploy:
+    name: Deploy
+    environment: Deployment
+    needs: test
+    runs-on: ubuntu-22.04
+    if: github.ref=='refs/heads/main' && github.event_name!='pull_request'
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.9"
+
+      - name: Check release
+        id: check_release
+        run: |
+          python -m pip install poetry githubrelease httpx==0.18.2 autopub twine wheel
+          echo "release=$(autopub check)" >> $GITHUB_OUTPUT
+
+      - name: Publish
+        if: ${{ steps.check_release.outputs.release=='' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
+          TWINE_USERNAME: "__token__"
+          TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+        run: |
+          git remote set-url origin https://$GITHUB_TOKEN@github.com/${{ github.repository }}
+          autopub deploy

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 dist/
 build
 .coverage
+poetry.lock

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,8 +1,6 @@
 Changelog
 ---------
 
-A list of changes between each release.
-
 0.9.6 (2022-11-5)
 ^^^^^^^^^^^^^^^^^^^
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[tool.poetry]
+name = "pytest-sugar"
+version = "0.9.6"
+description = "Pytest plugin that adds a progress bar and other visual enhancements"
+authors = ["Teemu <orkkiolento@gmail.com>", "Janne Vanhala <janne.vanhala@gmail.com>"]
+license = "BSD"
+readme = "README.md"
+keywords = ["testing", "pytest", "plugin"]
+
+repository = "https://github.com/Teemu/pytest-sugar"
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: BSD License",
+    "Operating System :: POSIX",
+    "Operating System :: Microsoft :: Windows",
+    "Operating System :: MacOS :: MacOS X",
+    "Topic :: Software Development :: Testing",
+    "Topic :: Software Development :: Libraries",
+    "Topic :: Utilities",
+]
+
+[tool.poetry.urls]
+"Tracker" = "https://github.com/Teemu/pytest-sugar/issues"
+
+[tool.poetry.dependencies]
+python = ">=3.8.1,<4.0"
+pytest = ">=6.2.0"
+termcolor = ">=2.1.0"
+packaging = ">=21.3"
+
+[tool.poetry.dev-dependencies]
+black = "^23.0"
+flake8 = "^3.9"
+isort = "^5.12"
+
+[tool.autopub]
+project-name = "pytest-sugar"
+git-username = "botpub"
+git-email = "52496925+botpub@users.noreply.github.com"
+append-github-contributor = true
+changelog-file = "CHANGES.rst"
+changelog-header = "---------"
+version-header = "^"
+version-strings = ["pytest_sugar.py"]
+build-system = "setuptools"
+
+[build-system]
+requires = ["setuptools >= 40.6.0", "wheel"]


### PR DESCRIPTION
Automate the process of Git-tagging new versions, creating releases on GitHub, and publishing packages to PyPI — all via GitHub Actions and [AutoPub](https://justinmayer.com/projects/autopub/).

Closes #137