### PR TITLE
Fix usage of deprecated startdir parameter

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -276,8 +276,12 @@ class SugarTerminalReporter(TerminalReporter):  # type: ignore
             ),
             bold=True,
         )
+        if int(pytest.__version__.split(".")[0]) <= 6:
+            hook_call_kwargs = {"startdir": self.startpath}
+        else:
+            hook_call_kwargs = {"start_path": self.startpath}
         lines = self.config.hook.pytest_report_header(
-            config=self.config, startdir=self.startpath
+            config=self.config, **hook_call_kwargs
         )
         lines.reverse()
         for line in flatten(lines):


### PR DESCRIPTION
Use the start_path parameter instead of startdir, since Pytest 7 yield the following deprecation warning if startdir is being used:

    site-packages/pytest_sugar.py:279: PytestRemovedIn8Warning:
    The (startdir: py.path.local) argument is deprecated, please
    use (start_path: pathlib.Path)

Details of the Pytest deprecation can be found from: https://docs.pytest.org/en/latest/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path

Fixes #232