### PR TITLE
Release `pytest-sugar` v1.0.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 ---
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -14,22 +14,22 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.10.1
+    rev: v3.15.0
     hooks:
       - id: pyupgrade
         args: [--py38-plus]
 
   - repo: https://github.com/psf/black
-    rev: 23.7.0
+    rev: 24.1.1
     hooks:
       - id: black
 
   - repo: https://github.com/PyCQA/flake8
-    rev: 6.1.0
+    rev: 7.0.0
     hooks:
       - id: flake8
 
   - repo: https://github.com/PyCQA/isort
-    rev: 5.12.0
+    rev: 5.13.2
     hooks:
       - id: isort

--- a/CONTRIBUTORS.rst
+++ b/CONTRIBUTORS.rst
@@ -3,6 +3,7 @@ The following people have contributed to pytest-sugar:
 * Janne Vanhala
 * Teemu
 * Marc Abramowitz
+* `Justin Mayer <https://justinmayer.com>`_
 * Yizhe Tang
 * Mahdi Yusuf
 * dscerri

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # pytest-sugar ✨
 
-[![PyPI version](https://img.shields.io/pypi/v/pytest-sugar.svg)](https://pypi.org/project/pytest-sugar/)
+[![Build Status](https://img.shields.io/github/actions/workflow/status/Teemu/pytest-sugar/build-and-test.yaml?branch=main)](https://github.com/Teemu/pytest-sugar/actions)
+[![PyPI Version](https://img.shields.io/pypi/v/pytest-sugar.svg)](https://pypi.org/project/pytest-sugar/)
+[![Downloads](https://img.shields.io/pypi/dm/pytest-sugar)](https://pypi.org/project/pytest-sugar/)
+![License](https://img.shields.io/pypi/l/pytest-sugar?color=blue)
 
 This plugin extends [pytest](http://pytest.org) by showing failures and errors instantly, adding a progress bar, improving the test results, and making the output look better.
 
@@ -26,8 +29,7 @@ If you would like to run tests without pytest-sugar, use:
 
 ## How to contribute 👷‍♂️
 
-[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=10950375
-)
+[![Open in GitHub Codespaces](https://github.com/codespaces/badge.svg)](https://github.com/codespaces/new?hide_repo_select=true&ref=master&repo=10950375)
 
 Make sure to read our [Code of Conduct](https://github.com/Teemu/pytest-sugar/blob/master/.github/CODE_OF_CONDUCT.md). You can get started modifying the codebase with the following commands. Alternatively, you can try Github Codespaces (click the badge above). Push the changes to your repository & create a pull request.
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,4 @@
+Release type: major
+
+* Add support for pytest 8.x
+* Drop support for Python 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,9 +31,9 @@ termcolor = ">=2.1.0"
 packaging = ">=21.3"
 
 [tool.poetry.dev-dependencies]
-black = "^23.0"
-flake8 = "^6.0"
-isort = "^5.12"
+black = "^24.0"
+flake8 = "^7.0"
+isort = "^5.13"
 
 [tool.autopub]
 project-name = "pytest-sugar"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,6 @@ authors = ["Teemu <orkkiolento@gmail.com>", "Janne Vanhala <janne.vanhala@gmail.
 license = "BSD 3-Clause"
 readme = "README.md"
 keywords = ["testing", "pytest", "plugin"]
-
-repository = "https://github.com/Teemu/pytest-sugar"
-
 classifiers = [
     "Development Status :: 5 - Production/Stable",
     "Environment :: Console",
@@ -21,7 +18,8 @@ classifiers = [
 ]
 
 [tool.poetry.urls]
-"Tracker" = "https://github.com/Teemu/pytest-sugar/issues"
+Homepage = "https://github.com/Teemu/pytest-sugar"
+"Issue Tracker" = "https://github.com/Teemu/pytest-sugar/issues"
 
 [tool.poetry.dependencies]
 python = ">=3.8.1,<4.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,11 @@ keywords = ["testing", "pytest", "plugin"]
 repository = "https://github.com/Teemu/pytest-sugar"
 
 classifiers = [
-    "Development Status :: 4 - Beta",
+    "Development Status :: 5 - Production/Stable",
+    "Environment :: Console",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: BSD License",
-    "Operating System :: POSIX",
-    "Operating System :: Microsoft :: Windows",
-    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: OS Independent",
     "Topic :: Software Development :: Testing",
     "Topic :: Software Development :: Libraries",
     "Topic :: Utilities",

--- a/setup.py
+++ b/setup.py
@@ -29,10 +29,9 @@ setup(
     long_description=codecs.open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     version=get_version("pytest_sugar.py"),
-    url="https://pivotfinland.com/pytest-sugar/",
+    url="https://github.com/Teemu/pytest-sugar",
     project_urls={
-        "Source": "https://github.com/Teemu/pytest-sugar/",
-        "Tracker": "https://github.com/Teemu/pytest-sugar/issues",
+        "Issue Tracker": "https://github.com/Teemu/pytest-sugar/issues",
     },
     license="BSD",
     author="Teemu, Janne Vanhala and others",


### PR DESCRIPTION
**Merging this pull request will _automatically release_ `pytest-sugar` v1.0.0.**

In addition, this PR includes the following changes:

* Set GitHub repository URL as home page URL on PyPI — #276
* Upgrade code style linters
* Update PyPI classifiers
* Add additional status badges to top of README

Closes #269