### PR TITLE
Add Python 3.13 to test configuration

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -14,8 +14,8 @@ jobs:
             python: 3.8
 
           # Latest Python & Pytest
-          - toxenv: py312-pytest_latest-supported-xdist
-            python: 3.12
+          - toxenv: py313-pytest_latest-supported-xdist
+            python: 3.13
 
           # QA
           - toxenv: qa

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,7 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py{38,312,py}-pytest_latest-supported-xdist
+envlist = py{38,313,py}-pytest_latest-supported-xdist
           qa
 requires = virtualenv>=20.0.31
 


### PR DESCRIPTION
This PR adds Python 3.13 to the test configuration.

Note: all tests pass when running `tox` locally, but the following `flake8` violation appeared:

```
qa: commands[0]> flake8 conftest.py pytest_sugar.py setup.py test_sugar.py
pytest_sugar.py:443:9: F824 `global LEN_PROGRESS_BAR_SETTING` is unused: name is never assigned in scope
qa: exit 1 (0.32 seconds) /home/cgoldberg617/code/pytest-sugar> flake8 conftest.py pytest_sugar.py setup.py test_sugar.py pid=10619
```
However, the pre-commit hook ran fine.
I don't think it is related to this PR.