### PR TITLE
Fix conflict with other Pytest plugins

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,3 @@
+Release type: patch
+
+Adjust signature of SugarTerminalReporter to avoid conflicts with other pytest plugins

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -16,9 +16,10 @@ import re
 import sys
 import time
 from configparser import ConfigParser  # type: ignore
-from typing import Any, Dict, Generator, List, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, Generator, List, Optional, Sequence, TextIO, Tuple, Union
 
 import pytest
+from _pytest.config import Config
 from _pytest.config.argparsing import Parser
 from _pytest.main import Session
 from _pytest.nodes import Item
@@ -206,7 +207,7 @@ def pytest_configure(config) -> None:
     if IS_SUGAR_ENABLED and not getattr(config, "slaveinput", None):
         # Get the standard terminal reporter plugin and replace it with our
         standard_reporter = config.pluginmanager.getplugin("terminalreporter")
-        sugar_reporter = SugarTerminalReporter(standard_reporter)
+        sugar_reporter = SugarTerminalReporter(standard_reporter.config)
         config.pluginmanager.unregister(standard_reporter)
         config.pluginmanager.register(sugar_reporter, "terminalreporter")
 
@@ -245,9 +246,9 @@ def pytest_report_teststatus(report: BaseReport) -> Optional[Tuple[str, str, str
     return report.outcome, letter, report.outcome.upper()
 
 
-class SugarTerminalReporter(TerminalReporter):  # type: ignore
-    def __init__(self, reporter) -> None:
-        TerminalReporter.__init__(self, reporter.config)
+class SugarTerminalReporter(TerminalReporter):
+    def __init__(self, config: Config, file: Union[TextIO, None] = None) -> None:
+        TerminalReporter.__init__(self, config, file)
         self.paths_left = []
         self.tests_count = 0
         self.tests_taken = 0

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -1,8 +1,9 @@
+import io
 import re
 
 import pytest
 
-from pytest_sugar import strip_colors
+from pytest_sugar import SugarTerminalReporter, strip_colors
 
 pytest_plugins = "pytester"
 
@@ -52,6 +53,16 @@ def assert_count(testdir, *args):
 
 
 class TestTerminalReporter:
+    def test_sugar_terminal_reporter_init_signature(self, pytestconfig):
+        terminal_reporter = pytestconfig.pluginmanager.getplugin("terminalreporter")
+        sugar_reporter = SugarTerminalReporter(terminal_reporter.config)
+        assert sugar_reporter.config is terminal_reporter.config
+
+        file_obj = io.StringIO()
+        sugar_reporter = SugarTerminalReporter(terminal_reporter.config, file=file_obj)
+        assert sugar_reporter.config is terminal_reporter.config
+        assert sugar_reporter._tw._file is file_obj
+
     def test_new_summary(self, testdir):
         testdir.makepyfile(
             """


### PR DESCRIPTION
# Description

Using pytest-sugar with another 3rd-party pytest plugins can cause conflicts  
As for example when using pytest-sugar with [pytest-durations](https://pypi.org/project/pytest-durations/) as `pytest --pytest-resultlog=duration.log .` leads to such error after pytest execution

```sh
venv/lib/python3.11/site-packages/pytest_durations/plugin.py", line 119, in pytest_terminal_summary
    terminalreporter = type(terminalreporter)(config=config, file=result_log_fp)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: SugarTerminalReporter.__init__() got an unexpected keyword argument 'config'
```

The main reason is that  `SugarTerminalReporter.__init__` differs from it's base class and it **breaks** further usage 

This PR fixes this kind of issue