### PR TITLE
safeguard against IndexError

### DIFF
--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -345,6 +345,8 @@ class SugarTerminalReporter(TerminalReporter):
                 if last < block:
                     progressbar += colored(bar[last:block], last_theme, on_color)
 
+                if block >= len(bar):
+                    break
                 progressbar += colored(bar[block], theme, on_color)
                 last = block + 1
                 last_theme = theme

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -591,3 +591,30 @@ class TestTerminalReporter:
                 "*-*test_doctest_lineno.py*:3*",
             ]
         )
+
+    def test_flaky_rerun(self, testdir):
+        pytest.importorskip("flaky")
+        testdir.makepyfile(
+            """
+            import pytest
+            from flaky import flaky
+
+            @pytest.mark.parametrize("x", range(200))
+            def test_lots1(x):
+                assert True
+
+            @flaky
+            def test_flaky():
+                assert False
+
+            @pytest.mark.parametrize("x", range(80))
+            def test_lots2(x):
+                assert True
+            """
+        )
+        result = testdir.runpytest("--force-sugar", "--no-flaky-report")
+
+        assert result.ret == 1, result.stderr.str()
+        test_counts = get_counts(result.stdout.str())
+        assert test_counts["passed"] == "280"
+        assert test_counts["failed"] == "1"

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -12,9 +12,9 @@ def get_counts(stdout):
     output = strip_colors(stdout)
 
     def _get(x):
-        m = re.search(r"\d %s" % x, output)
+        m = re.search(r"(\d+) %s" % x, output)
         if m:
-            return m.group()[0]
+            return m.group(1)
         return "n/a"
 
     return {

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ deps =
     supported-xdist: pytest-xdist
     supported-xdist: pytest-forked
     pytest-cov
+    flaky
 commands =
     pytest --cov --cov-config=.coveragerc {posargs:test_sugar.py}
 


### PR DESCRIPTION
I got this error (also reported by others at #190)
```
INTERNALERROR>   File "/Users/brondsem/dev/pytest-sugar/pytest_sugar.py", line 482, in pytest_runtest_logreport
INTERNALERROR>     self.insert_progress(report)
INTERNALERROR>   File "/Users/brondsem/dev/pytest-sugar/pytest_sugar.py", line 359, in insert_progress
INTERNALERROR>     append_string = get_progress_bar()
INTERNALERROR>                     ^^^^^^^^^^^^^^^^^^
INTERNALERROR>   File "/Users/brondsem/dev/pytest-sugar/pytest_sugar.py", line 350, in get_progress_bar
INTERNALERROR>     progressbar += colored(bar[block], theme, on_color)
INTERNALERROR>                            ~~~^^^^^^^
INTERNALERROR> IndexError: string index out of range
```

I was able to reproduce it with `@flaky`.  In most situations everything runs fine, but with a large # of tests I was able to reproduce.  Other plugins/configs might be able to trigger it also, not sure.  Here's the flaky example:

```py
import pytest
from flaky import flaky

@pytest.mark.parametrize("x", range(200))
def test_lots1(x):
    assert True

@flaky
def test_flaky():
    assert False

@pytest.mark.parametrize("x", range(80))
def test_lots2(x):
    assert True
```

So I've added a simple safeguard to avoid the error.