### PR TITLE
Add support for Python 3.14 and pytest 9, drop Python 3.8-3.9 and pytest 6

### DIFF
--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -1,6 +1,6 @@
 name: build
 
-on: [push, pull_request]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   test:
@@ -14,8 +14,8 @@ jobs:
             python: 3.8
 
           # Latest Python & Pytest
-          - toxenv: py313-pytest_latest-supported-xdist
-            python: 3.13
+          - toxenv: py314-pytest_latest-supported-xdist
+            python: 3.14
 
           # QA
           - toxenv: qa

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,9 +9,9 @@ jobs:
       fail-fast: false # run all tests anyway
       matrix:
         include:
-          # Python 3.8 && Pytest 6.2
-          - toxenv: py38-pytest62-supported-xdist
-            python: 3.8
+          # Python 3.10 && Pytest 6.2
+          - toxenv: py310-pytest62-supported-xdist
+            python: "3.10"
 
           # Latest Python & Pytest
           - toxenv: py314-pytest_latest-supported-xdist
@@ -19,7 +19,7 @@ jobs:
 
           # QA
           - toxenv: qa
-            python: 3.8
+            python: "3.10"
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python
@@ -53,7 +53,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.9"
+          python-version: "3.x"
 
       - name: Check release
         id: check_release

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -9,8 +9,8 @@ jobs:
       fail-fast: false # run all tests anyway
       matrix:
         include:
-          # Python 3.10 && Pytest 6.2
-          - toxenv: py310-pytest62-supported-xdist
+          # Python 3.10 && Pytest 7
+          - toxenv: py310-pytest7-supported-xdist
             python: "3.10"
 
           # Latest Python & Pytest

--- a/.github/workflows/build-and-test.yaml
+++ b/.github/workflows/build-and-test.yaml
@@ -21,9 +21,9 @@ jobs:
           - toxenv: qa
             python: 3.8
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
           cache: 'pip'
@@ -48,10 +48,10 @@ jobs:
     if: github.ref=='refs/heads/main' && github.event_name!='pull_request'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.9"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
       - id: pyupgrade
         args: [--py38-plus]
 
-  - repo: https://github.com/psf/black
+  - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1
     hooks:
       - id: black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,7 +17,7 @@ repos:
     rev: v3.15.0
     hooks:
       - id: pyupgrade
-        args: [--py38-plus]
+        args: [--py310-plus]
 
   - repo: https://github.com/psf/black-pre-commit-mirror
     rev: 24.1.1

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ For long-running tests, display minutes and not only seconds.
 
 You will need the following prerequisites in order to use pytest-sugar:
 
-- Python 3.8 or newer
+- Python 3.10 or newer
 - pytest 6.2 or newer
 
 ## Running on Windows

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ For long-running tests, display minutes and not only seconds.
 You will need the following prerequisites in order to use pytest-sugar:
 
 - Python 3.10 or newer
-- pytest 6.2 or newer
+- pytest 7 or newer
 
 ## Running on Windows
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ Homepage = "https://github.com/Teemu/pytest-sugar"
 "Issue Tracker" = "https://github.com/Teemu/pytest-sugar/issues"
 
 [tool.poetry.dependencies]
-python = ">=3.8.1,<4.0"
+python = ">=3.10,<4.0"
 pytest = ">=6.2.0"
 termcolor = ">=2.1.0"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ Homepage = "https://github.com/Teemu/pytest-sugar"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4.0"
-pytest = ">=6.2.0"
+pytest = ">=7"
 termcolor = ">=2.1.0"
 
 [tool.poetry.dev-dependencies]

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -15,8 +15,9 @@ import os
 import re
 import sys
 import time
+from collections.abc import Generator, Sequence
 from configparser import ConfigParser  # type: ignore
-from typing import Any, Dict, Generator, List, Optional, Sequence, TextIO, Tuple, Union
+from typing import Any, TextIO
 
 import pytest
 from _pytest.config import Config
@@ -32,23 +33,23 @@ __version__ = "1.1.1"
 LEN_RIGHT_MARGIN = 0
 LEN_PROGRESS_PERCENTAGE = 5
 LEN_PROGRESS_BAR_SETTING = "10"
-LEN_PROGRESS_BAR: Optional[int] = None
+LEN_PROGRESS_BAR: int | None = None
 
 
 @dataclasses.dataclass
 class Theme:
-    header: Optional[str] = "magenta"
-    skipped: Optional[str] = "blue"
-    success: Optional[str] = "green"
-    warning: Optional[str] = "yellow"
-    fail: Optional[str] = "red"
-    error: Optional[str] = "red"
-    xfailed: Optional[str] = "green"
-    xpassed: Optional[str] = "red"
-    progressbar: Optional[str] = "green"
-    progressbar_fail: Optional[str] = "red"
-    progressbar_background: Optional[str] = "grey"
-    path: Optional[str] = "cyan"
+    header: str | None = "magenta"
+    skipped: str | None = "blue"
+    success: str | None = "green"
+    warning: str | None = "yellow"
+    fail: str | None = "red"
+    error: str | None = "red"
+    xfailed: str | None = "green"
+    xpassed: str | None = "red"
+    progressbar: str | None = "green"
+    progressbar_fail: str | None = "red"
+    progressbar_background: str | None = "grey"
+    path: str | None = "cyan"
     name = None
     symbol_passed: str = "✓"
     symbol_skipped: str = "s"
@@ -57,16 +58,16 @@ class Theme:
     symbol_xfailed_skipped: str = "x"
     symbol_xfailed_failed: str = "X"
     symbol_unknown: str = "?"
-    unknown: Optional[str] = "blue"
-    symbol_rerun: Optional[str] = "R"
-    rerun: Optional[str] = "blue"
+    unknown: str | None = "blue"
+    symbol_rerun: str | None = "R"
+    rerun: str | None = "blue"
 
     def __getitem__(self, x):
         return getattr(self, x)
 
 
 THEME: Theme = Theme()
-PROGRESS_BAR_BLOCKS: List[str] = [
+PROGRESS_BAR_BLOCKS: list[str] = [
     " ",
     "▏",
     "▎",
@@ -155,8 +156,8 @@ def pytest_sessionstart(session: Session) -> None:
     config = ConfigParser()
     config.read(["pytest-sugar.conf", os.path.expanduser("~/.pytest-sugar.conf")])
 
-    theme_attributes: Dict[str, Optional[str]] = {}
-    fields: Tuple[dataclasses.Field, ...] = dataclasses.fields(Theme)
+    theme_attributes: dict[str, str | None] = {}
+    fields: tuple[dataclasses.Field, ...] = dataclasses.fields(Theme)
 
     for field in fields:
         key = field.name
@@ -164,7 +165,7 @@ def pytest_sessionstart(session: Session) -> None:
             continue
 
         value_str: str = config.get("theme", key).lower()
-        value: Optional[str] = value_str
+        value: str | None = value_str
         if value in ("", "none"):
             value = None
 
@@ -212,7 +213,7 @@ def pytest_configure(config) -> None:
         config.pluginmanager.register(sugar_reporter, "terminalreporter")
 
 
-def pytest_report_teststatus(report: BaseReport) -> Optional[Tuple[str, str, str]]:
+def pytest_report_teststatus(report: BaseReport) -> tuple[str, str, str] | None:
     if not IS_SUGAR_ENABLED:
         return None
 
@@ -247,7 +248,7 @@ def pytest_report_teststatus(report: BaseReport) -> Optional[Tuple[str, str, str
 
 
 class SugarTerminalReporter(TerminalReporter):
-    def __init__(self, config: Config, file: Union[TextIO, None] = None) -> None:
+    def __init__(self, config: Config, file: TextIO | None = None) -> None:
         TerminalReporter.__init__(self, config, file)
         self.paths_left = []
         self.tests_count = 0
@@ -301,7 +302,7 @@ class SugarTerminalReporter(TerminalReporter):
     def write_fspath_result(self, nodeid: str, res, **markup: bool) -> None:
         return
 
-    def insert_progress(self, report: Union[CollectReport, TestReport]) -> None:
+    def insert_progress(self, report: CollectReport | TestReport) -> None:
         def get_progress_bar() -> str:
             length = LEN_PROGRESS_BAR
             if not length:
@@ -397,7 +398,7 @@ class SugarTerminalReporter(TerminalReporter):
         )
 
     def begin_new_line(
-        self, report: Union[CollectReport, TestReport], print_filename: bool
+        self, report: CollectReport | TestReport, print_filename: bool
     ) -> None:
         path = self.report_key(report)
         self.current_line_num += 1
@@ -435,7 +436,7 @@ class SugarTerminalReporter(TerminalReporter):
         self.write("\r\n")
 
     def reached_last_column_for_test_status(
-        self, report: Union[CollectReport, TestReport]
+        self, report: CollectReport | TestReport
     ) -> bool:
         len_line = real_string_length(self.current_lines[self.report_key(report)])
         return len_line >= self.get_max_column_for_test_status()
@@ -450,7 +451,7 @@ class SugarTerminalReporter(TerminalReporter):
         # pytest's default progress
         pass
 
-    def report_key(self, report: Union[CollectReport, TestReport]) -> Any:
+    def report_key(self, report: CollectReport | TestReport) -> Any:
         """Returns a key to identify which line the report should write to."""
         return (
             (report.location or "") if self.showlongtestinfo else (report.fspath or "")
@@ -615,7 +616,7 @@ class SugarTerminalReporter(TerminalReporter):
                 colored("   % 5d deselected" % self.count("deselected"), THEME.warning)
             )
 
-    def _find_playwright_trace(self, report: TestReport) -> Optional[str]:
+    def _find_playwright_trace(self, report: TestReport) -> str | None:
         """
         Finds the Playwright trace file associated with a specific test report.
 
@@ -727,7 +728,7 @@ class SugarTerminalReporter(TerminalReporter):
         # show the error instantly after error has occurred.
         pass
 
-    def print_failure(self, report: Union[CollectReport, TestReport]) -> None:
+    def print_failure(self, report: CollectReport | TestReport) -> None:
         # https://github.com/Frozenball/pytest-sugar/issues/34
         if hasattr(report, "wasxfail"):
             return

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -288,12 +288,8 @@ class SugarTerminalReporter(TerminalReporter):
             ),
             bold=True,
         )
-        if int(pytest.__version__.split(".")[0]) <= 6:
-            hook_call_kwargs = {"startdir": self.startpath}
-        else:
-            hook_call_kwargs = {"start_path": self.startpath}
         lines = self.config.hook.pytest_report_header(
-            config=self.config, **hook_call_kwargs
+            config=self.config, start_path=self.startpath
         )
         lines.reverse()
         for line in flatten(lines):

--- a/pytest_sugar.py
+++ b/pytest_sugar.py
@@ -454,7 +454,7 @@ class SugarTerminalReporter(TerminalReporter):
         )
 
     def pytest_runtest_logreport(self, report: TestReport) -> None:
-        global LEN_PROGRESS_BAR_SETTING, LEN_PROGRESS_BAR
+        global LEN_PROGRESS_BAR
 
         res = pytest_report_teststatus(report=report)
         assert res

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     zip_safe=False,
     include_package_data=True,
     platforms="any",
-    install_requires=["pytest>=6.2.0", "termcolor>=2.1.0"],
+    install_requires=["pytest>=7", "termcolor>=2.1.0"],
     extras_require={
         "dev": [
             "black",

--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ setup(
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Programming Language :: Python :: Implementation :: PyPy",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         " look and feel of pytest (e.g. progressbar, show tests that"
         " fail instantly)."
     ),
-    long_description=codecs.open("README.md", encoding="utf-8").read(),
+    long_description=open("README.md", encoding="utf-8").read(),
     long_description_content_type="text/markdown",
     version=get_version("pytest_sugar.py"),
     url="https://github.com/Teemu/pytest-sugar",
@@ -60,8 +60,6 @@ setup(
         "Topic :: Software Development :: Libraries",
         "Topic :: Utilities",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -112,9 +112,13 @@ class TestTerminalReporter:
         assert_count(testdir)
 
     def test_report_header(self, testdir):
+        if int(pytest.__version__.split(".")[0]) <= 6:
+            header_arg = "startdir"
+        else:
+            header_arg = "start_path"
         testdir.makeconftest(
-            """
-            def pytest_report_header(startdir):
+            f"""
+            def pytest_report_header({header_arg}):
                 pass
             """
         )

--- a/test_sugar.py
+++ b/test_sugar.py
@@ -112,13 +112,9 @@ class TestTerminalReporter:
         assert_count(testdir)
 
     def test_report_header(self, testdir):
-        if int(pytest.__version__.split(".")[0]) <= 6:
-            header_arg = "startdir"
-        else:
-            header_arg = "start_path"
         testdir.makeconftest(
-            f"""
-            def pytest_report_header({header_arg}):
+            """
+            def pytest_report_header(start_path):
                 pass
             """
         )

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py{38,314,py}-pytest_latest-supported-xdist
+envlist = py{310,314,py}-pytest_latest-supported-xdist
           qa
 requires = virtualenv>=20.0.31
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 minversion = 3.14.0
-envlist = py{38,313,py}-pytest_latest-supported-xdist
+envlist = py{38,314,py}-pytest_latest-supported-xdist
           qa
 requires = virtualenv>=20.0.31
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ requires = virtualenv>=20.0.31
 [testenv]
 install_command = python -m pip install --use-feature=fast-deps {opts} {packages}
 deps =
-    pytest62: pytest~=6.2.5
+    pytest7: pytest~=7.4
     pytest_latest: pytest
     termcolor>=1.1.0
     supported-xdist: pytest-xdist


### PR DESCRIPTION
Python 3.8-3.9 are EOL: https://devguide.python.org/versions/

When adding a new pytest, we can drop an old one.